### PR TITLE
Patch 2.7 deprecated setDefaultOption method

### DIFF
--- a/DependencyInjection/ElaoFormExtension.php
+++ b/DependencyInjection/ElaoFormExtension.php
@@ -36,13 +36,13 @@ class ElaoFormExtension extends Extension
     public function __construct()
     {
         $this->features = array(
-            'collection'    => "collection.xml",
-            'choice'        => "choice.xml",
-            'buttons'       => "buttons.xml",
-            'help'          => "help.xml",
-            'tooltip_label' => "tooltip_label.xml",
-            'placeholder'   => "placeholder.xml",
-            'confirm'       => "confirm.xml",
+            'collection'    => 'collection.xml',
+            'choice'        => 'choice.xml',
+            'buttons'       => 'buttons.xml',
+            'help'          => 'help.xml',
+            'tooltip_label' => 'tooltip_label.xml',
+            'placeholder'   => 'placeholder.xml',
+            'confirm'       => 'confirm.xml',
         );
     }
 

--- a/Form/Extension/CollectionTypeExtension.php
+++ b/Form/Extension/CollectionTypeExtension.php
@@ -13,7 +13,7 @@ namespace Elao\Bundle\FormBundle\Form\Extension;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\Form\AbstractTypeExtension;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * Extension for the CollectionType, provides:
@@ -33,7 +33,7 @@ class CollectionTypeExtension extends AbstractTypeExtension
     /**
      * {@inheritdoc}
      */
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefined(array('min', 'max'));
         $resolver->setDefaults(

--- a/Form/Extension/FormButtonTypeExtension.php
+++ b/Form/Extension/FormButtonTypeExtension.php
@@ -14,7 +14,7 @@ use Symfony\Component\Form\AbstractTypeExtension;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * Extension for the FormType, provides:
@@ -33,7 +33,7 @@ class FormButtonTypeExtension extends AbstractTypeExtension
     /**
      * {@inheritdoc}
      */
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefined(self::getButtons());
     }

--- a/Form/Extension/FormConfirmTypeExtension.php
+++ b/Form/Extension/FormConfirmTypeExtension.php
@@ -13,7 +13,7 @@ namespace Elao\Bundle\FormBundle\Form\Extension;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\Form\AbstractTypeExtension;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * Extension for the FormType, provides a confirm option
@@ -31,7 +31,7 @@ class FormConfirmTypeExtension extends AbstractTypeExtension
     /**
      * {@inheritdoc}
      */
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(['confirm' => false]);
     }

--- a/Form/Extension/FormHelpTypeExtension.php
+++ b/Form/Extension/FormHelpTypeExtension.php
@@ -13,7 +13,7 @@ namespace Elao\Bundle\FormBundle\Form\Extension;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\Form\AbstractTypeExtension;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * Extension for the FormType, provides:
@@ -32,7 +32,7 @@ class FormHelpTypeExtension extends AbstractTypeExtension
     /**
      * {@inheritdoc}
      */
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(array('help' => false));
     }

--- a/Form/Extension/FormPlaceholderTypeExtension.php
+++ b/Form/Extension/FormPlaceholderTypeExtension.php
@@ -13,7 +13,7 @@ namespace Elao\Bundle\FormBundle\Form\Extension;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\Form\AbstractTypeExtension;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * Extension for the FormType, provides a placeholder option
@@ -31,7 +31,7 @@ class FormPlaceholderTypeExtension extends AbstractTypeExtension
     /**
      * {@inheritdoc}
      */
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(['placeholder' => false]);
     }

--- a/Form/Extension/FormTooltipLabelTypeExtension.php
+++ b/Form/Extension/FormTooltipLabelTypeExtension.php
@@ -13,7 +13,7 @@ namespace Elao\Bundle\FormBundle\Form\Extension;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\Form\AbstractTypeExtension;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * Extension for the FormType, provides a tooltip option
@@ -31,7 +31,7 @@ class FormTooltipLabelTypeExtension extends AbstractTypeExtension
     /**
      * {@inheritdoc}
      */
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults([
             'tooltip_label' => false,

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
         }
     ],
     "require": {
-        "symfony/framework-bundle": "~2.7"
+        "symfony/framework-bundle": "~2.3",
+        "symfony/form": "~2.7"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Replace deprecated setDefaultOption method by the new configureOption method introduced in Symfony 2.7